### PR TITLE
SKS-25700 Adding cloud build items

### DIFF
--- a/build.tfvars
+++ b/build.tfvars
@@ -1,0 +1,2 @@
+image = "gcr-proxy"
+folder = "."

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,24 @@
+steps:
+  - name: "gcr.io/cloud-builders/docker"
+    entrypoint: "bash"
+    args: ["/workspace/docker-build.sh"]
+    env:
+      [
+        "PROJECTS=$PROJECT_ID",
+        "IMAGES=$_IMAGE",
+        "SHORT_SHA=$SHORT_SHA",
+        "BRANCH_NAME=$BRANCH_NAME",
+        "DOCKER_DIR=.",
+      ]
+    dir: "${_DIR}"
+
+substitutions:
+  _IMAGE: "gcr-proxy"
+  _DIR: "."
+
+timeout: 1800s
+
+logsBucket: gs://${PROJECT_ID}_cloudbuild/logs
+
+images:
+  - "gcr.io/${PROJECT_ID}/${_IMAGE}"

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+BRANCH_TAG=$(echo "${BRANCH_NAME}" | tr "/" "_")
+
+tags=""
+build_args=""
+docker_file_arg=""
+
+for project in $PROJECTS; do
+  for image in $IMAGES; do
+    tags="$tags -t gcr.io/${project}/${image}:${SHORT_SHA} -t gcr.io/${project}/${image}:${BRANCH_TAG} \
+      -t us-docker.pkg.dev/${project}/gcr.io/${image}:${BRANCH_TAG} -t  us-docker.pkg.dev/${project}/gcr.io/${image}:${SHORT_SHA}"
+  done
+done  
+
+if [ ! -z "$ARGUMENTS" ]; then
+  build_args="--build-arg $ARGUMENTS"
+fi
+
+if [ ! -z "$DOCKER_FILE" ]; then
+  docker_file_arg="--file=$DOCKER_FILE"
+fi
+
+docker build $tags $build_args $DOCKER_DIR $docker_file_arg
+
+exit $?


### PR DESCRIPTION
Adding the cloud build components so we can build and host this image ourselves.

This is required for the work in https://github.com/cysiv/docker_mirror/pull/16

Background: Ahmet Alp Balkan is a Google engineer and really good with Kubernetes. He wrote a blog about how to put a custom FQDN in front of a Google Artifact Registry using this code in a Cloud Run Service.

Since this workload will provide images that our customers trust to run in their environment, I felt it prudent for us to build the code from our own GitHub org. I expect few (if any) changes to this image during the lifetime of the Registry Mirror.